### PR TITLE
Varchar overflow in comments model bugfix

### DIFF
--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :comment do
     title { Faker::Lorem.sentence }
-    text { Faker::Lorem.paragraph }
+    text { Faker::Lorem.paragraph[0..254] }
   end
 end


### PR DESCRIPTION
https://semaphoreapp.com/fs/rails-base-api/branches/some-code-refactoring/builds/2

Failure/Error: let!(:comment) { FactoryGirl.create :comment, user: user }
     ActiveRecord::StatementInvalid:
       PG::StringDataRightTruncation: ERROR:  value too long for type character varying(255)
       : INSERT INTO "comments" ("created_at", "text", "title", "updated_at", "user_id") VALUES ($1, $2, $3, $4, $5) RETURNING "id"
