### PR TITLE
Use letter_opener in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -16,6 +16,9 @@ Rails.application.configure do
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 
+  # Open letters in browser
+  config.action_mailer.delivery_method = :letter_opener
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -16,7 +16,7 @@ Rails.application.configure do
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 
-  # Open letters in browser
+  # Preview email in the browser instead of sending it.
   config.action_mailer.delivery_method = :letter_opener
 
   # Print deprecation notices to the Rails logger.


### PR DESCRIPTION
We have dependency for letter_opener gem in Gemfile, but it's not initialized for using in development so let's fix it.