### PR TITLE
fix incorrect CORS response for sign_in

### DIFF
--- a/config/initializers/rack_cors.rb
+++ b/config/initializers/rack_cors.rb
@@ -1,4 +1,4 @@
-app_config.middleware.use Rack::Cors do
+app_config.middleware.insert_before 'Warden::Manager', 'Rack::Cors' do
   allow do
     # Allow requests from domains:
     # e.g. origins('api.example.com', 'next.example.com')


### PR DESCRIPTION
When you will try to get error message from server during signing in with Devise, you will receive broken response without message, so move `Rack::Cors` before `Warden::Manager` in the middleware stack to prevent it.

Proof: https://github.com/cyu/rack-cors

> Warden will return immediately if a resource that requires authentication is accessed without authentication. If `Warden::Manager` is in the stack before `Rack::Cors`, it will return without the correct CORS headers being applied, resulting in a failed CORS request. Be sure to
insert this middleware before `Warden::Manager`.