### PR TITLE
Add id to error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Add id to error response
+  ([#183](https://github.com/fs/rails-base-api/pull/183))
 * Upgrade Active Model Serializer to 0.10.0.rc2
   ([#182](https://github.com/fs/rails-base-api/pull/182))
 * Rename bin/bootstrap to bin/setup

--- a/doc/api/v1/errors/request_to_unexisting_page.json
+++ b/doc/api/v1/errors/request_to_unexisting_page.json
@@ -23,7 +23,7 @@
       "request_content_type": null,
       "response_status": 404,
       "response_status_text": "Not Found",
-      "response_body": "{\"error\":{\"status\":404,\"error\":\"Not Found\",\"validations\":null}}",
+      "response_body": "{\"error\":{\"id\":\"f5576af0-303e-4ca4-b421-ba741116d4a4\",\"status\":404,\"error\":\"Not Found\",\"validations\":null}}",
       "response_headers": {
         "Content-Type": "application/json; charset=utf-8"
       },

--- a/doc/api/v1/index.json
+++ b/doc/api/v1/index.json
@@ -14,13 +14,13 @@
       "name": "Sessions",
       "examples": [
         {
-          "description": "Sign in with invalid password",
-          "link": "sessions/sign_in_with_invalid_password.json",
+          "description": "Sign in with valid password",
+          "link": "sessions/sign_in_with_valid_password.json",
           "groups": "all"
         },
         {
-          "description": "Sign in with valid password",
-          "link": "sessions/sign_in_with_valid_password.json",
+          "description": "Sign in with invalid password",
+          "link": "sessions/sign_in_with_invalid_password.json",
           "groups": "all"
         }
       ]

--- a/doc/api/v1/sessions/sign_in_with_invalid_password.json
+++ b/doc/api/v1/sessions/sign_in_with_invalid_password.json
@@ -23,7 +23,7 @@
     {
       "request_method": "POST",
       "request_path": "/v1/users/sign_in",
-      "request_body": "email=user1%40example.com&password=",
+      "request_body": "email=user2%40example.com&password=",
       "request_headers": {
         "Accept": "application/json"
       },
@@ -32,12 +32,12 @@
       "request_content_type": "application/x-www-form-urlencoded",
       "response_status": 401,
       "response_status_text": "Unauthorized",
-      "response_body": "{\"error\":{\"status\":401,\"error\":\"Invalid email or password.\",\"validations\":null}}",
+      "response_body": "{\"error\":{\"id\":\"19acd4f1-2fa1-4c6d-9d95-6cf8d7e8aaa7\",\"status\":401,\"error\":\"Invalid email or password.\",\"validations\":null}}",
       "response_headers": {
         "Content-Type": "application/json; charset=utf-8"
       },
       "response_content_type": "application/json; charset=utf-8",
-      "curl": "curl \"http://localhost:5000/v1/users/sign_in\" -d 'email=user1%40example.com&password=' -X POST \\\n\t-H \"Accept: application/json\""
+      "curl": "curl \"http://localhost:5000/v1/users/sign_in\" -d 'email=user2%40example.com&password=' -X POST \\\n\t-H \"Accept: application/json\""
     }
   ]
 }

--- a/doc/api/v1/sessions/sign_in_with_valid_password.json
+++ b/doc/api/v1/sessions/sign_in_with_valid_password.json
@@ -23,7 +23,7 @@
     {
       "request_method": "POST",
       "request_path": "/v1/users/sign_in",
-      "request_body": "email=user2%40example.com&password=123456",
+      "request_body": "email=user1%40example.com&password=123456",
       "request_headers": {
         "Accept": "application/json"
       },
@@ -32,12 +32,12 @@
       "request_content_type": "application/x-www-form-urlencoded",
       "response_status": 201,
       "response_status_text": "Created",
-      "response_body": "{\"user\":{\"id\":2,\"authentication_token\":\"ttvV4SUVHQL29TZTC9b-\",\"email\":\"user2@example.com\"}}",
+      "response_body": "{\"user\":{\"id\":1,\"authentication_token\":\"ac2zWyKFhnoaWEggD7tn\",\"email\":\"user1@example.com\"}}",
       "response_headers": {
         "Content-Type": "application/json; charset=utf-8"
       },
       "response_content_type": "application/json; charset=utf-8",
-      "curl": "curl \"http://localhost:5000/v1/users/sign_in\" -d 'email=user2%40example.com&password=123456' -X POST \\\n\t-H \"Accept: application/json\""
+      "curl": "curl \"http://localhost:5000/v1/users/sign_in\" -d 'email=user1%40example.com&password=123456' -X POST \\\n\t-H \"Accept: application/json\""
     }
   ]
 }

--- a/lib/rails_api_format/lib/rails_api_format/error.rb
+++ b/lib/rails_api_format/lib/rails_api_format/error.rb
@@ -1,12 +1,15 @@
+require 'securerandom'
+
 module RailsApiFormat
   class Error
     include ActiveModel::Model
     include ActiveModel::Serialization
 
-    attr_accessor :status, :error, :validations
+    attr_accessor :id, :status, :error, :validations
 
     def attributes
       {
+        id: id,
         status: status,
         error: error,
         validations: validations
@@ -21,6 +24,10 @@ module RailsApiFormat
 
     def status
       Rack::Utils.status_code(@status)
+    end
+
+    def id
+      @id || ENV.fetch('ACTION_DISPATCH_REQUEST_ID', SecureRandom.uuid)
     end
   end
 end

--- a/lib/rails_api_format/lib/rails_api_format/error_serializer.rb
+++ b/lib/rails_api_format/lib/rails_api_format/error_serializer.rb
@@ -1,6 +1,6 @@
 module RailsApiFormat
   class ErrorSerializer < ActiveModel::Serializer
-    attributes :status, :error, :validations
+    attributes :id, :status, :error, :validations
 
     private
 


### PR DESCRIPTION
In case we would like to switch to [json-api](http://jsonapi.org/format/#errors) format it will require to have id for serialized object.

Id based on `ENV['ACTION_DISPATCH_REQUEST_ID']` or generated using `SecureRandom.uuid`