### PR TITLE
Switch off assets serve in application initializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Switch off static assets serve
+  ([#192](https://github.com/fs/rails-base-api/pull/192))
 * Update Rails to 4.2.4 and Ruby to 2.2.3
   ([#193](https://github.com/fs/rails-base-api/pull/193))
 * Sync Rubocop rules with Rails-Base

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,6 +29,8 @@ module RailsBaseApi
     # Default host for action mailer, initializers/mailer.rb
     config.host = "localhost:5000"
 
+    config.serve_static_assets = false
+
     # Disable default Rails headers which do not make sense in
     # API-only project (X-Frame-Options, X-XSS-Protection, X-Content-Type-Options)
     config.action_dispatch.default_headers = {}


### PR DESCRIPTION
According to rack-cors documentation [https://github.com/cyu/rack-cors] will be more clearly to switch off serve static files inside the API-application to reduce the middleware stack and avoid common CORS errors.