### PR TITLE
Rename serve_static_assets configuration to serve_static_files

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -29,7 +29,7 @@ module RailsBaseApi
     # Default host for action mailer, initializers/mailer.rb
     config.host = "localhost:5000"
 
-    config.serve_static_assets = false
+    config.serve_static_files = false
 
     # Disable default Rails headers which do not make sense in
     # API-only project (X-Frame-Options, X-XSS-Protection, X-Content-Type-Options)


### PR DESCRIPTION
`config.serve_static_assets` has been deprecated since Rails 4.2 and renamed to `config.serve_static_files`. @timurvafin please take a look